### PR TITLE
fix word-wrapping for "LOG" Page

### DIFF
--- a/react/pages/ContainerInfo.jsx
+++ b/react/pages/ContainerInfo.jsx
@@ -115,7 +115,7 @@ class ContainerInfo extends Component {
                 label="Wrap output"
                 className={classes.switch}
               />
-              <Typography component='pre' className={classes.pre} style={wrapped ? { whiteSpace: 'pre-wrap' } : {}}>
+              <Typography component='pre' className={classes.pre} style={wrapped ? { whiteSpace: 'pre-wrap', wordBreak: 'break-all' } : {}}>
                 {containerInfo.content}
               </Typography>
             </div>


### PR DESCRIPTION
With this change the new-line always breaks at the end of the display.